### PR TITLE
fix(softDelete): ajout query#includeDeleted & entity#isDeleted, fix store()

### DIFF
--- a/source/entities/EntityDefinition.js
+++ b/source/entities/EntityDefinition.js
@@ -196,9 +196,19 @@ class EntityDefinition {
    */
   flush (cb) {
     const collection = this.getCollection();
-    // Si la collection n'existe pas, "MongoError: ns not found" est renvoyée
-    if (collection) collection.drop(cb);
-    else cb();
+    // Si la collection n'existe pas, getCollection renvoie un objet
+    // mais "MongoError: ns not found" est renvoyé sur le drop
+    if (collection) {
+      collection.drop(function (error) {
+        if (error) {
+          if (/ns not found/.test(error.message)) return cb()
+          return cb(error)
+        }
+        cb()
+      });
+    } else {
+      cb();
+    }
   }
 
   /**

--- a/source/entities/EntityQuery.js
+++ b/source/entities/EntityQuery.js
@@ -43,6 +43,7 @@ class EntityQuery {
     this.entity = entity;
     this.clauses = [];
     this.search = null;
+    this._includeDeleted = false;
   }
 
   /**
@@ -256,6 +257,15 @@ class EntityQuery {
   }
 
   /**
+   * Remonte uniquement toutes les entités softdeleted ou non
+   * @return {EntityQuery}
+   */
+  includeDeleted() {
+    this._includeDeleted = true;
+    return this
+  }
+
+  /**
    * Remonte les entités softDeleted après when
    * @param {Date} when
    * @return {EntityQuery}
@@ -384,8 +394,8 @@ class EntityQuery {
       Object.assign(query[index], condition);
     })
 
-    // Par défaut, on ne prend pas les softDeleted
-    if (!query['__deletedAt']) query['__deletedAt'] = {$eq : null}
+    // par défaut on prend pas les softDeleted
+    if (!query['__deletedAt'] && !this._includeDeleted) query['__deletedAt'] = {$eq : null}
   }
 
   /**

--- a/source/entities/EntityQuery.js
+++ b/source/entities/EntityQuery.js
@@ -62,6 +62,20 @@ class EntityQuery {
   }
 
   /**
+   * Limite les enregistrements dont la valeur (de l'index imposé précédemment) est différente à une
+   * valeur donnée.
+   * @param {String|Integer|Date} value La valeur cherchée
+   * @return {EntityQuery} La requête (chaînable donc}
+   */
+  notEquals (value, fieldValue) {
+    if (typeof fieldValue !== 'undefined') {
+      this.match(value);
+      value = fieldValue;
+    }
+    return this.alterLastMatch({value: value,  operator: '<>'});
+  }
+
+  /**
    * Limite les enregistrements dont la valeur (de l'index imposé précédemment) ressemble à une
    * valeur donnée (Cf signification du _ et % avec like).
    * @see https://dev.mysql.com/doc/refman/5.5/en/pattern-matching.html
@@ -343,6 +357,10 @@ class EntityQuery {
       switch (clause.operator) {
         case '=':
           condition = {$eq: cast(clause.value)};
+          break;
+
+        case '<>':
+          condition = {$ne: cast(clause.value)};
           break;
 
         case '>':


### PR DESCRIPTION
- Ajout d'une méthode `EntityQuery#includeDeleted()` pour faire une requête sur les entités soft-deleted *et* les autres.
- Ajout d'une méthode `Entity#isDeleted()` pour identifier les entités soft-deleted
- Fix: un `Entity#store()` sur une entité soft-deleted ne doit pas la restaurer (il faut utiliser `restore()`)

Pour une raison à déterminer les tests ne passent pas sur le `master` actuel en partant d'une nouvelle base mongo de test (TODO: fix), mais j'ai pu tester les corrections du softDelete sur un ancienne version.
Apparemment ça marche dans certaines conditions avec une base de test pré-existante (ping @qboisson peux tu lancer les tests de cette PR ?).

Sur une base de test vide on a l'erreur : 
```
$entities-cli
Lancement avec les paramètres de connexion
{ name: 'testLassi',
  host: 'localhost',
  port: 27017,
  authMechanism: 'DEFAULT',
  authSource: '',
  options: { poolSize: 10 } }
Connexion mongo OK
    1) "before all" hook: Connexion à Mongo et initialisation des entités

  $entities
Lancement avec les paramètres de connexion
{ name: 'testLassi',
  host: 'localhost',
  port: 27017,
  authMechanism: 'DEFAULT',
  authSource: '',
  options: { poolSize: 10 } }
Connexion mongo OK
    2) "before all" hook: Connexion à Mongo et initialisation des entités


  0 passing (73ms)
  2 failing

  1) $entities-cli "before all" hook: Connexion à Mongo et initialisation des entités:
     MongoError: ns not found
      at Function.MongoError.create (node_modules/mongodb-core/lib/error.js:31:11)
      at node_modules/mongodb-core/lib/connection/pool.js:497:72
      at authenticateStragglers (node_modules/mongodb-core/lib/connection/pool.js:443:16)
      at Connection.messageHandler (node_modules/mongodb-core/lib/connection/pool.js:477:5)
      at Socket.<anonymous> (node_modules/mongodb-core/lib/connection/connection.js:331:22)
      at addChunk (_stream_readable.js:266:12)
      at readableAddChunk (_stream_readable.js:253:11)
      at Socket.Readable.push (_stream_readable.js:211:10)
      at TCP.onread (net.js:585:20)

  2) $entities "before all" hook: Connexion à Mongo et initialisation des entités:
     MongoError: ns not found
      at Function.MongoError.create (node_modules/mongodb-core/lib/error.js:31:11)
      at node_modules/mongodb-core/lib/connection/pool.js:497:72
      at authenticateStragglers (node_modules/mongodb-core/lib/connection/pool.js:443:16)
      at Connection.messageHandler (node_modules/mongodb-core/lib/connection/pool.js:477:5)
      at Socket.<anonymous> (node_modules/mongodb-core/lib/connection/connection.js:331:22)
      at addChunk (_stream_readable.js:266:12)
      at readableAddChunk (_stream_readable.js:253:11)
      at Socket.Readable.push (_stream_readable.js:211:10)
      at TCP.onread (net.js:585:20)
```