### PR TITLE
Fix/default max age

### DIFF
--- a/source/Action.js
+++ b/source/Action.js
@@ -105,6 +105,9 @@ class Action {
       if (lassi.settings && lassi.settings.pathProperties && lassi.settings.pathProperties[this.path]) {
         _.extend(options, lassi.settings.pathProperties[this.path]);
       }
+      // par défaut, express met un max-age à 0 (cf http://expressjs.com/en/4x/api.html#express.static)
+      // si l'appli ne précise rien on le met à 1d sur le statique
+      if (!options.hasOwnProperty('maxAge')) options.maxAge = '1d'
       var serveStatic = express.static(this.fsPath, options);
       this.middleware = (function(base) {
         return function(request, response, next) {

--- a/source/Action.js
+++ b/source/Action.js
@@ -106,8 +106,8 @@ class Action {
         _.extend(options, lassi.settings.pathProperties[this.path]);
       }
       // par défaut, express met un max-age à 0 (cf http://expressjs.com/en/4x/api.html#express.static)
-      // si l'appli ne précise rien on le met à 1d sur le statique
-      if (!options.hasOwnProperty('maxAge')) options.maxAge = '1d'
+      // si l'appli ne précise rien on le met à 1h sur le statique
+      if (!options.hasOwnProperty('maxAge')) options.maxAge = '1h'
       var serveStatic = express.static(this.fsPath, options);
       this.middleware = (function(base) {
         return function(request, response, next) {


### PR DESCRIPTION
On met 1d par défaut, ça évitera pas mal de requête qui ne font que répondre 304 (avec le maxAge: 0 par défaut d'express, le navigateur redemande à chaque fois en précisant un etag, et varnish doit faire suivre à node pour savoir, il ne cache donc rien)