### PR TITLE
ajout de EntityQuery#setDebug

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "jsdoc": "^3.5.5",
     "mocha": "^2.5.3",
+    "pre-push": "^0.1.1",
     "sinon": "^4.0.1",
     "sinon-chai": "^2.14.0"
   },
@@ -61,6 +62,7 @@
       "lassi": true
     }
   },
+  "pre-push": ["test", "lint"],
   "readmeFilename": "README.md",
   "readme": "",
   "description": "",

--- a/source/entities/EntityQuery.js
+++ b/source/entities/EntityQuery.js
@@ -136,6 +136,7 @@ function buildQuery (entityQuery, record) {
 
   // par défaut on prend pas les softDeleted
   if (!query['__deletedAt'] && !entityQuery._includeDeleted) query['__deletedAt'] = {$eq: null}
+  if (entityQuery.debug) log('mongoQuery', record)
 } // buildQuery
 
 /**
@@ -362,6 +363,17 @@ class EntityQuery {
         callback(null, groupes)
       })
       .catch(callback)
+  }
+
+  /**
+   * Ajoute (ou enlève) le mode debug qui log les params de la requêtes 
+   * (qui peuvent être passé tels quels dans un mongo-shell)
+   * @param {boolean} [status=true]
+   * @return {EntityQuery} La requête (pour chaînage)
+   */
+  setDebug (status = true) {
+    this.debug = status
+    return this
   }
 
   /**

--- a/source/entities/EntityQuery.js
+++ b/source/entities/EntityQuery.js
@@ -366,7 +366,7 @@ class EntityQuery {
   }
 
   /**
-   * Ajoute (ou enlève) le mode debug qui log les params de la requêtes 
+   * Ajoute (ou enlève) le mode debug qui log les params de la requête
    * (qui peuvent être passé tels quels dans un mongo-shell)
    * @param {boolean} [status=true]
    * @return {EntityQuery} La requête (pour chaînage)


### PR DESCRIPTION
Juste pour ajouter du query.setDebug() qui log les arguments de la requête mongo en console (pour pouvoir les copier/coller dans du shell mongo).