### PR TITLE
Remove "null" and "undefined" values before a store

### DIFF
--- a/source/entities/Entity.js
+++ b/source/entities/Entity.js
@@ -104,13 +104,15 @@ class Entity {
    * @return {Object}
    */
   values () {
-    // on vire les _, $ et méthodes, puis serialize et sauvegarde
+    // on vire les _, null, undefined, $ et méthodes, puis serialize et sauvegarde
     // mais on les conserve sur l'entité elle-même car ça peut être utiles pour le afterStore
     //
     // On utilise _pick() pour passer outre une éventuelle méthode toJSON() qui viendrait modifier le contenu "jsonifié"
     // de l'entity (par exemple pour masquer le champ 'password' sur un utilisateur)
     return _.pickBy(this, function (v, k) {
       if (_.isFunction(v)) return false
+      if (v === null) return false
+      if (v === undefined) return false
       if (k[0] === '_') return false
       if (k[0] === '$') return false
       return true

--- a/source/entities/Entity.js
+++ b/source/entities/Entity.js
@@ -100,33 +100,31 @@ class Entity {
   }
 
   /**
-   * Retourne l'entity sans ses méthodes ni ses propriétés préfixées avec $ ou _
+   * Retourne l'entity en supprimant certaines de ses données :
+   * - les attributs ayant un nom commençant par "_" ou "$"
+   * - les attributs ayant des valeurs null ou undefined (profondément)
    * @return {Object}
    */
   values () {
-    // on vire les _, $ et méthodes, puis serialize et sauvegarde
-    // mais on les conserve sur l'entité elle-même car ça peut être utiles pour le afterStore
-    //
-    // On utilise _pick() pour passer outre une éventuelle méthode toJSON() qui viendrait modifier le contenu "jsonifié"
-    // de l'entity (par exemple pour masquer le champ 'password' sur un utilisateur)
-    let object = _.pickBy(this, function (v, k) {
-      if (_.isFunction(v)) return false
-      if (k[0] === '_') return false
-      if (k[0] === '$') return false
-      return true
-    })
-
-    // On supprime aussi les valeurs null et undefined de façon récursif
-    const removeNullAndUndefinedValues = (obj) => {
+    const copyCleanProps = (obj, dest, isFirstLevel = false) => {
       Object.keys(obj).forEach(key => {
-        if (obj[key] && typeof obj[key] === 'object') removeNullAndUndefinedValues(obj[key])
-        else if (obj[key] === null || obj[key] === undefined) delete obj[key]
+        const v = obj[key]
+        // au 1er niveau on ajoute ce filtre
+        if (isFirstLevel && (key[0] === '_' || key[0] === '$')) return
+        if (v === null || v === undefined || typeof v === 'function') return
+        // on ne veut que les objets qui n'ont pas d'autre constructeur que Object (ni Regexp ni Date ni Array,
+        // mais les objets "maison" définis avec un constructeur classique passent ce filtre)
+        if (typeof v === 'object' && Object.prototype.toString.call(v) === '[object Object]') {
+          dest[key] = {}
+          copyCleanProps(v, dest[key])
+        } else {
+          dest[key] = v
+        }
       })
-
-      return obj
+      return dest
     }
 
-    return removeNullAndUndefinedValues(object)
+    return copyCleanProps(this, {}, true)
   }
 
   /**

--- a/source/entities/Entity.js
+++ b/source/entities/Entity.js
@@ -104,19 +104,29 @@ class Entity {
    * @return {Object}
    */
   values () {
-    // on vire les _, null, undefined, $ et méthodes, puis serialize et sauvegarde
+    // on vire les _, $ et méthodes, puis serialize et sauvegarde
     // mais on les conserve sur l'entité elle-même car ça peut être utiles pour le afterStore
     //
     // On utilise _pick() pour passer outre une éventuelle méthode toJSON() qui viendrait modifier le contenu "jsonifié"
     // de l'entity (par exemple pour masquer le champ 'password' sur un utilisateur)
-    return _.pickBy(this, function (v, k) {
+    let object = _.pickBy(this, function (v, k) {
       if (_.isFunction(v)) return false
-      if (v === null) return false
-      if (v === undefined) return false
       if (k[0] === '_') return false
       if (k[0] === '$') return false
       return true
     })
+
+    // On supprime aussi les valeurs null et undefined de façon récursif
+    const removeNullAndUndefinedValues = (obj) => {
+      Object.keys(obj).forEach(key => {
+        if (obj[key] && typeof obj[key] === 'object') removeNullAndUndefinedValues(obj[key])
+        else if (obj[key] === null || obj[key] === undefined) delete obj[key]
+      })
+
+      return obj
+    }
+
+    return removeNullAndUndefinedValues(object)
   }
 
   /**

--- a/test/entities-indexed.js
+++ b/test/entities-indexed.js
@@ -14,6 +14,8 @@ let TestEntity
 
 describe('Test entities-queries', function () {
   before('Connexion à Mongo et initialisation des entités', function (done) {
+    // Evite les erreurs de timeout sur une machine lente (ou circleCI)
+    this.timeout(60000)
     flow().seq(function () {
       setup(this)
     }).seq(function (Entity) {

--- a/test/entities-indexes.js
+++ b/test/entities-indexes.js
@@ -39,6 +39,8 @@ describe('Test entities-indexes', function () {
   let db
 
   before('Connexion à Mongo et initialisation des entités', function (done) {
+    // Evite les erreurs de timeout sur une machine lente (ou circleCI)
+    this.timeout(60000)
     let dbSettings
     flow().seq(function () {
       setup(this)

--- a/test/entities-queries.js
+++ b/test/entities-queries.js
@@ -120,7 +120,7 @@ function addData (next) {
 describe('Test entities-queries', function () {
   before('Connexion à Mongo et initialisation des entités', function (done) {
     // Evite les erreurs de timeout sur une machine lente (ou circleCI)
-    this.timeout(20000)
+    this.timeout(60000)
     flow().seq(function () {
       setup(this)
     }).seq(function (Entity) {

--- a/test/entities-search.js
+++ b/test/entities-search.js
@@ -28,7 +28,7 @@ function initEntities (dbSettings, next) {
 
 describe('Test entities-search', function () {
   before('Connexion à Mongo et initialisation des entités', function (done) {
-    this.timeout(20000)
+    this.timeout(60000)
     flow().seq(function () {
       setup(this)
     }).seq(function (Entity, dbSettings) {

--- a/test/entities.js
+++ b/test/entities.js
@@ -190,7 +190,20 @@ describe('Entity', () => {
     })
 
     it('enlève les attributs "null" ou "undefined" en bdd', (done) => {
-      const entity = TestEntity.create({nonTemporaire: 1, nullValue: null, undefinedValue: undefined, child: {deepNumber: 6, deepUndefined: undefined}})
+      const entity = TestEntity.create({
+        nonTemporaire: 1,
+        nullValue: null,
+        undefinedValue: undefined,
+        child: {
+          deepArray: [],
+          deepDate: new Date(),
+          deepFunction: () => 'hello',
+          deepNumber: 6,
+          deepRegexp: new RegExp(),
+          deepUndefined: undefined
+        }
+      })
+
       flow()
         .seq(function () {
           entity.store(this)
@@ -199,11 +212,23 @@ describe('Entity', () => {
           TestEntity.match('oid').equals(oid).grabOne(this)
         })
         .seq(function (dbEntity) {
+          // Test de l'entité provenant de la BDD
           expect(dbEntity.nonTemporaire).to.equal(1)
-          expect(dbEntity.nullValue).to.be.undefined
-          expect(dbEntity.undefinedValue).to.be.undefined
           expect(dbEntity.child.deepNumber).to.equal(6)
-          expect(dbEntity.child.deepUndefined).to.be.undefined
+
+          expect(dbEntity).to.not.have.property('nullValue')
+          expect(dbEntity).to.not.have.property('undefinedValue')
+          expect(dbEntity.child).to.not.have.property('deepFunction')
+
+          expect(dbEntity.child).to.have.property('deepDate')
+          expect(dbEntity.child).to.have.property('deepRegexp')
+          expect(dbEntity.child).to.have.property('deepArray')
+
+          // Vérifie que le store n'a pas modifié l'objet original
+          expect(entity).to.have.property('nullValue')
+          expect(entity).to.have.property('undefinedValue')
+          expect(entity.child).to.have.property('deepFunction')
+
           this()
         })
         .done(done)

--- a/test/entities.js
+++ b/test/entities.js
@@ -189,6 +189,24 @@ describe('Entity', () => {
         .done(done)
     })
 
+    it('enlève les attributs "null" ou "undefined" en bdd', (done) => {
+      const entity = TestEntity.create({nonTemporaire: 1, nullValue: null, undefinedValue: undefined})
+      flow()
+        .seq(function () {
+          entity.store(this)
+        })
+        .seq(function ({oid}) {
+          TestEntity.match('oid').equals(oid).grabOne(this)
+        })
+        .seq(function (dbEntity) {
+          expect(dbEntity.nonTemporaire).to.equal(1)
+          expect(dbEntity.nullValue).to.be.undefined
+          expect(dbEntity.undefinedValue).to.be.undefined
+          this()
+        })
+        .done(done)
+    })
+
     describe('.afterStore', () => {
       it(`est appelée avec un oid lors d'une création`, (done) => {
         // Cas d'utilisation principale du afterStore :

--- a/test/entities.js
+++ b/test/entities.js
@@ -15,7 +15,7 @@ let TestEntity
 //       ou ramener les tests qui sont dans entities-queries.js
 describe('Entity', () => {
   before(function (done) {
-    this.timeout(20000)
+    this.timeout(60000)
     flow()
       .seq(function () {
         setup(this)

--- a/test/entities.js
+++ b/test/entities.js
@@ -190,7 +190,7 @@ describe('Entity', () => {
     })
 
     it('enlève les attributs "null" ou "undefined" en bdd', (done) => {
-      const entity = TestEntity.create({nonTemporaire: 1, nullValue: null, undefinedValue: undefined})
+      const entity = TestEntity.create({nonTemporaire: 1, nullValue: null, undefinedValue: undefined, child: {deepNumber: 6, deepUndefined: undefined}})
       flow()
         .seq(function () {
           entity.store(this)
@@ -202,6 +202,8 @@ describe('Entity', () => {
           expect(dbEntity.nonTemporaire).to.equal(1)
           expect(dbEntity.nullValue).to.be.undefined
           expect(dbEntity.undefinedValue).to.be.undefined
+          expect(dbEntity.child.deepNumber).to.equal(6)
+          expect(dbEntity.child.deepUndefined).to.be.undefined
           this()
         })
         .done(done)


### PR DESCRIPTION
Trello: [Card](https://trello.com/c/2vHuMLZB/46-5-nettoyer-les-propri%C3%A9t%C3%A9s-facultatives-ayant-une-valeur-nullundefined-dans-lassi)

Notes : 
- Après discussion il est plus simple de totalement ignorer les valeurs "null" et "undefined", la validation AJV s'occupera du reste
-  La suppression de la condition sur les attributs commençant par "_" demande quelques changements (La restauration d'une entité pose problème), ce changement fera donc l'objet d'un prochain ticket